### PR TITLE
Prevent basic NPE when Activity is not set

### DIFF
--- a/android/src/main/java/com/bluechilli/flutteruploader/FlutterUploaderPlugin.java
+++ b/android/src/main/java/com/bluechilli/flutteruploader/FlutterUploaderPlugin.java
@@ -58,7 +58,10 @@ public class FlutterUploaderPlugin implements MethodCallHandler, Application.Act
     final MethodChannel channel = new MethodChannel(registrar.messenger(), CHANNEL_NAME);
     final FlutterUploaderPlugin plugin = new FlutterUploaderPlugin(registrar, channel);
     channel.setMethodCallHandler(plugin);
-    registrar.activity().getApplication().registerActivityLifecycleCallbacks(plugin);
+
+    if (registrar.activity() != null) {
+      registrar.activity().getApplication().registerActivityLifecycleCallbacks(plugin);
+    }
   }
 
   private FlutterUploaderPlugin(Registrar registrar, MethodChannel channel) {


### PR DESCRIPTION
The plugin may be instantiated in non-activity related Isolates, in which case the activity object on the registrar will be null.