### PR TITLE
Build example projects on CI

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,8 +1,8 @@
 FROM cirrusci/flutter:stable
 
 RUN yes | sdkmanager \
-    "platforms;android-27" \
-    "build-tools;27.0.3" \
+    "platforms;android-28" \
+    "build-tools;28.0.3" \
     "extras;google;m2repository" \
     "extras;android;m2repository"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,4 @@
-task:
+code_style_task:
   container:
     dockerfile: .ci/Dockerfile
     cpu: 8
@@ -22,3 +22,16 @@ task:
         - flutter packages get
         - pub global run tuneup check
 
+android_task:
+  container:
+    dockerfile: .ci/Dockerfile
+    cpu: 8
+    memory: 16G
+  build_script:
+    - cd example && flutter build apk --release
+
+ios_task:
+  osx_instance:
+    image: mojave-flutter
+  build_script:
+    - cd example && flutter build ios --release --no-codesign


### PR DESCRIPTION
Extends the Cirrus script so that iOS & Android example are built on the CI.