### PR TITLE
Keep instances of progress and result stream

### DIFF
--- a/lib/src/flutter_uploader.dart
+++ b/lib/src/flutter_uploader.dart
@@ -43,67 +43,56 @@ class FlutterUploader {
   /// stream to listen on upload progress
   ///
   Stream<UploadTaskProgress> get progress {
-    if (_progressStream == null) {
-      _progressStream = _progressChannel
-          .receiveBroadcastStream()
-          .map<Map<String, dynamic>>(
-              (event) => Map<String, dynamic>.from(event))
-          .transform(StreamTransformer<Map<String, dynamic>,
-              UploadTaskProgress>.fromHandlers(
-        handleData:
-            (Map<String, dynamic> map, EventSink<UploadTaskProgress> sink) {
-          String id = map['taskId'];
-          int status = map['status'];
-          int uploadProgress = map['progress'];
-          final t = UploadTaskProgress(
-              id, uploadProgress, UploadTaskStatus.from(status));
+    return _progressStream ??= _progressChannel
+        .receiveBroadcastStream()
+        .map<Map<String, dynamic>>((event) => Map<String, dynamic>.from(event))
+        .transform(StreamTransformer<Map<String, dynamic>,
+            UploadTaskProgress>.fromHandlers(
+      handleData:
+          (Map<String, dynamic> map, EventSink<UploadTaskProgress> sink) {
+        String id = map['taskId'];
+        int status = map['status'];
+        int uploadProgress = map['progress'];
+        final t = UploadTaskProgress(
+            id, uploadProgress, UploadTaskStatus.from(status));
 
-          sink.add(t);
-        },
-      ));
-    }
-
-    return _progressStream;
+        sink.add(t);
+      },
+    ));
   }
 
   ///
   /// stream to listen on upload result
   ///
   Stream<UploadTaskResponse> get result {
-    if (_resultStream == null) {
-      _resultStream = _resultChannel
-          .receiveBroadcastStream()
-          .map<Map<String, dynamic>>(
-              (event) => Map<String, dynamic>.from(event))
-          .transform(
-        StreamTransformer<Map<String, dynamic>,
-            UploadTaskResponse>.fromHandlers(
-          handleData:
-              (Map<String, dynamic> value, EventSink<UploadTaskResponse> sink) {
-            String id = value['taskId'];
-            String message = value['message'];
-            // String code = value['code'];
-            int status = value["status"];
-            int statusCode = value["statusCode"];
-            Map<String, dynamic> headers = value['headers'] != null
-                ? Map<String, dynamic>.from(value['headers'])
-                : {};
+    return _resultStream ??= _resultChannel
+        .receiveBroadcastStream()
+        .map<Map<String, dynamic>>((event) => Map<String, dynamic>.from(event))
+        .transform(
+      StreamTransformer<Map<String, dynamic>, UploadTaskResponse>.fromHandlers(
+        handleData:
+            (Map<String, dynamic> value, EventSink<UploadTaskResponse> sink) {
+          String id = value['taskId'];
+          String message = value['message'];
+          // String code = value['code'];
+          int status = value["status"];
+          int statusCode = value["statusCode"];
+          Map<String, dynamic> headers = value['headers'] != null
+              ? Map<String, dynamic>.from(value['headers'])
+              : {};
 
-            final r = UploadTaskResponse(
-              taskId: id,
-              status: UploadTaskStatus.from(status),
-              statusCode: statusCode,
-              headers: headers,
-              response: message,
-            );
+          final r = UploadTaskResponse(
+            taskId: id,
+            status: UploadTaskStatus.from(status),
+            statusCode: statusCode,
+            headers: headers,
+            response: message,
+          );
 
-            sink.add(r);
-          },
-        ),
-      );
-    }
-
-    return _resultStream;
+          sink.add(r);
+        },
+      ),
+    );
   }
 
   void dispose() {


### PR DESCRIPTION
I build a Widget which allows one to select files and then uploads them. Therefore, every file is managed as an own instance of the same widget which is starting the upload by its own and shows the progress of its upload. 

There I encountered the problem that only the last built widgets was updating the progress of its upload. After debugging for a while I found out that only the listeners of the last widget where actually called.

So it looks like the custom getters of both streams return different instances with every new call instead of returning the same instance and the old instances don't get called anymore.

I'm not sure why the other instances aren't called anymore. But it looks like EventChannels can only keep a reference to one BroadcastStream at the time. Is that the issue or do you have another idea?

But here is a fix. 