### PR TITLE
Keep instances of progress and result stream

### DIFF
--- a/lib/src/flutter_uploader.dart
+++ b/lib/src/flutter_uploader.dart
@@ -5,6 +5,9 @@ class FlutterUploader {
   final EventChannel _progressChannel;
   final EventChannel _resultChannel;
 
+  Stream<UploadTaskProgress> _progressStream;
+  Stream<UploadTaskResponse> _resultStream;
+
   static FlutterUploader _instance;
 
   factory FlutterUploader() {
@@ -40,7 +43,7 @@ class FlutterUploader {
   /// stream to listen on upload progress
   ///
   Stream<UploadTaskProgress> get progress {
-    return _progressChannel
+    return _progressStream ??= _progressChannel
         .receiveBroadcastStream()
         .map<Map<String, dynamic>>((event) => Map<String, dynamic>.from(event))
         .transform(StreamTransformer<Map<String, dynamic>,
@@ -62,7 +65,7 @@ class FlutterUploader {
   /// stream to listen on upload result
   ///
   Stream<UploadTaskResponse> get result {
-    return _resultChannel
+    return _resultStream ??= _resultChannel
         .receiveBroadcastStream()
         .map<Map<String, dynamic>>((event) => Map<String, dynamic>.from(event))
         .transform(


### PR DESCRIPTION
I build a Widget which allows one to select files and then uploads them. Therefore, every file is managed as an own instance of the same widget which is starting the upload by its own and shows the progress of its upload.

There I encountered the problem that only the last built widgets was updating the progress of its upload. After debugging for a while I found out that only the listeners of the last widget where actually called.

So it looks like the custom getters of both streams return different instances with every new call instead of returning the same instance and the old instances don't get called anymore.

I'm not sure why the other instances aren't called anymore. But it looks like EventChannels can only keep a reference to one BroadcastStream at the time. Is that the issue or do you have another idea?

But here is a fix.

@ened first, sorry for the struggles. Second, I looked into adding driver tests but I'm not sure the tests would make any sense when I have to mock the EventChannel. What do you think about it?