### PR TITLE
#166 Fix ClassCastException on Android

### DIFF
--- a/android/src/main/java/com/bluechilli/flutteruploader/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/bluechilli/flutteruploader/MethodCallHandlerImpl.java
@@ -77,9 +77,9 @@ public class MethodCallHandlerImpl implements MethodCallHandler {
   }
 
   void setBackgroundHandler(MethodCall call, MethodChannel.Result result) {
-    Long callbackHandle = call.argument("callbackHandle");
+    Number callbackHandle = call.argument("callbackHandle");
     if (callbackHandle != null) {
-      SharedPreferenceHelper.saveCallbackDispatcherHandleKey(context, callbackHandle);
+      SharedPreferenceHelper.saveCallbackDispatcherHandleKey(context, callbackHandle.longValue());
     }
 
     result.success(null);


### PR DESCRIPTION
Due to Dart not always transporting the 
callback handle as a `long` the forced cast to 
`Long` on Android fails if the handle is only an 
`int`.
Props to @mbabker for finding this out.

As a solution, the number is cast to `Number` 
instead. The actual value can still be extracted
as a `long`.

Fixes #166 